### PR TITLE
export featured image url

### DIFF
--- a/Exporter.php
+++ b/Exporter.php
@@ -182,6 +182,10 @@ class Exporter
             return array();
         }
 
+        if ($featuredImageUrl = get_the_post_thumbnail_url($post->ID)) {
+            $metadata['featured_image_url'] = [$featuredImageUrl];
+        }
+
         return $metadata;
     }
 


### PR DESCRIPTION
Featured image url is added to the exported post's metadata with `featured_image_url` key. Current implementation ignores featured images altogether.